### PR TITLE
Allow plain LF as a line delimiter

### DIFF
--- a/src/modem/OwlModemAT.h
+++ b/src/modem/OwlModemAT.h
@@ -169,7 +169,6 @@ class OwlModemAT {
  private:
   enum class line_state_t {
     idle,
-    idle_expect_lf,
     in_line,
   };
 


### PR DESCRIPTION
SARA-N410-02B skips CR on some rare but critical occasions, let's be more permissive.