### PR TITLE
Remove garbage at the end of PEM credentials

### DIFF
--- a/src/modem/OwlModemSSLRN4.h
+++ b/src/modem/OwlModemSSLRN4.h
@@ -115,6 +115,7 @@ class OwlModemSSLRN4 {
   str ssl_response = {.s = nullptr, .len = 0};
   bool shouldWriteCertificate(usecmng_certificate_type_e type, str name, str new_value);
   int calculateMD5ForCert(char* output, int max_len, str input);
+  bool isPEM(str input);
 };
 
 #endif  // __OWL_MODEM_SSL_RN4_H__


### PR DESCRIPTION
Removes zero terminator if it happens to be added

Is normally the case for Arduino port when user specifies PEM-formatted credentials.